### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+ # Enable version updates for rust
+ - package-ecosystem: "cargo"
+   directory: "/"
+   schedule:
+     interval: "weekly"


### PR DESCRIPTION
has to be merged  into w/e the default branch is, maybe we should set the default to develop? 